### PR TITLE
Update autoloading for PSR-0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
     ],
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-0": { "PHPImageWorkshop": "src" }
     }
 }


### PR DESCRIPTION
Previously the classmap feature was failing to map the namespace or class to the correct location, meaning this class would not load at all.
