### PR TITLE
Replaced self:: with static:: to allow for correct extending of the class

### DIFF
--- a/src/PHPImageWorkshop/ImageWorkshop.php
+++ b/src/PHPImageWorkshop/ImageWorkshop.php
@@ -362,7 +362,7 @@ class ImageWorkshop
                     $layerTmpHeight = $totalHeightUnderLayer - $minLayerPositionY;
                 }
 
-                $layerTmp = new self(array(
+                $layerTmp = new static(array(
                     "width" => $layerTmpWidth,
                     "height" => $layerTmpHeight,
                 ));
@@ -378,7 +378,7 @@ class ImageWorkshop
 
             } else {
 
-                $layerTmp = new self(array(
+                $layerTmp = new static(array(
                     "imageVar" => $this->image,
                 ));
 
@@ -784,7 +784,7 @@ class ImageWorkshop
                     
                     if ($this->getWidth() != $newWidth || $this->getHeight() != $newHeight) {
                         
-                        $layerTmp = new self(array(
+                        $layerTmp = new static(array(
                             'width' => $newWidth,
                             'height' => $newHeight,
                         ));
@@ -1026,13 +1026,13 @@ class ImageWorkshop
         
         if (($width != $this->width || $positionX == 0) || ($height != $this->height || $positionY == 0)) {
             
-            $layerTmp = new self(array(
+            $layerTmp = new static(array(
                 'width' => $width,
                 'height' => $height,
                 'backgroundColor' => $backgroundColor,
             ));
             
-            $layerClone = new self(array(
+            $layerClone = new static(array(
                 'width' => $this->width,
                 'height' => $this->height,
             ));


### PR DESCRIPTION
self:: will reference the origininal class, as where static:: references the child class, which is what you want when extending.
