### PR TITLE
Update ImageWorkshopLayer.php

### DIFF
--- a/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
+++ b/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
@@ -745,7 +745,7 @@ class ImageWorkshopLayer
                         $layerTmp = ImageWorkshop::initVirginLayer($newWidth, $newHeight);
                         
                         $layerTmp->addLayer(1, $this, round($positionX * ($newWidth / 100)), round($positionY * ($newHeight / 100)), $position);
-                        
+                        $layerTmp->mergeAll();
                         $this->width = $layerTmp->getWidth();
                         $this->height = $layerTmp->getHeight();
                         unset($this->image);


### PR DESCRIPTION
Fixing a bug when adding a layer on top after resizing with converse proportions.

To recreate the bug:

``` php
$watermark = PHPImageWorkshop\ImageWorkshop::initFromPath('watermark.png');
$watermark->opacity(20);

$image = PHPImageWorkshop\ImageWorkshop::initFromPath('image.png');
$image->resizeInPixel(770, 770, true, 0, 0, 'MM');
$image->addLayerOnTop($watermark);
```

Expected result:
image.png resized to 770 x 770px with the watermark on top with opacity 20%

Actual result:
blank image resized to 770 x 770px with the watermark on top with opacity 20%
