### PR TITLE
Add 'interlace' flag for the save method of layer

### DIFF
--- a/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
+++ b/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
@@ -1384,7 +1384,7 @@ class ImageWorkshopLayer
      * @param string $backgroundColor
      * @param integer $imageQuality
      */
-    public function save($folder, $imageName, $createFolders = true, $backgroundColor = null, $imageQuality = 75)
+    public function save($folder, $imageName, $createFolders = true, $backgroundColor = null, $imageQuality = 75, $interlace = null)
     {
         if (!is_file($folder)) {
 
@@ -1408,6 +1408,10 @@ class ImageWorkshopLayer
                 }
 
                 $image = $this->getResult($backgroundColor);
+
+                if ($interlace !== null) {
+                    imageinterlace($image, $interlace);
+                }
 
                 if ($extension == 'jpg' || $extension == 'jpeg') {
 


### PR DESCRIPTION
Interlaced images progressively load in web browsers.

The default value of the flag does not apply any changes to the image, to preserve previous behavior.

This is similar to https://github.com/Sybio/ImageWorkshop/pull/11, but gives the caller full control over the interlace behavior.
