### PR TITLE
Get image stream

### DIFF
--- a/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
+++ b/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
@@ -1421,7 +1421,7 @@ class ImageWorkshopLayer
      */
     public function getResultAsPNG($backgroundColor = null, $quality = 75)
     {
-        $quality = floor(($quality > 100 ? 99:$quality) / 10);
+        $quality = floor(($quality >= 100 ? 99:$quality) / 10);
         ob_start();
         imagepng($this->getResult($backgroundColor), null, $quality);
         return ob_get_clean();


### PR DESCRIPTION
Methods to get a merged resource image as a raw image stream (a string) which can be saved into a file or served on the fly by printing the result with the proper headers. Makes use of PHP's output buffering.
#### Included methods
- `getResultAsPNG($backgroundColor = null, $quality = 75)`
- `getResultAsJPG($backgroundColor = null, $quality = 75, $interlace = false)`
- `getResultAsGIF($backgroundColor = null)`
