### PR TITLE
Fix setting background color when setting it to "000000"

### DIFF
--- a/src/PHPImageWorkshop/ImageWorkshop.php
+++ b/src/PHPImageWorkshop/ImageWorkshop.php
@@ -128,7 +128,7 @@ class ImageWorkshop
     {
         $opacity = 0;
         
-        if (!$backgroundColor || $backgroundColor == 'transparent') {
+        if (null === $backgroundColor || $backgroundColor == 'transparent') {
             $opacity = 127;
             $backgroundColor = 'ffffff';
         }


### PR DESCRIPTION
``` php
public static function initVirginLayer($width = 100, $height = 100, $backgroundColor = null)
{
    $opacity = 0;

    if (!$backgroundColor || $backgroundColor == 'transparent') {
        $opacity = 127;
        $backgroundColor = 'ffffff';
    }

    return new ImageWorkshopLayer(ImageWorkshopLib::generateImage($width, $height, $backgroundColor, $opacity));
}
```

If setting background with hexa code (#000000), $backgroundColor parameter is setting to "000000".

When the `if` instruction is executed `$backgroundColor` is cast to `bool` and his value is `false`.

This is a fix to prevent this bug.
