### PR TITLE
Fixed @param docblock comment for adding layers to an ImageWorkshopLayer...

### DIFF
--- a/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
+++ b/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
@@ -170,7 +170,7 @@ class ImageWorkshopLayer
      * $position: http://phpimageworkshop.com/doc/22/corners-positions-schema-of-an-image.html
      *
      * @param integer $layerLevel
-     * @param ImageWorkshop $layer
+     * @param ImageWorkshopLayer $layer
      * @param integer $positionX
      * @param integer $positionY
      * @param string $position
@@ -189,7 +189,7 @@ class ImageWorkshopLayer
      *
      * $position: http://phpimageworkshop.com/doc/22/corners-positions-schema-of-an-image.html
      *
-     * @param ImageWorkshop $layer
+     * @param ImageWorkshopLayer $layer
      * @param integer $positionX
      * @param integer $positionY
      * @param string $position
@@ -208,7 +208,7 @@ class ImageWorkshopLayer
      *
      * $position: http://phpimageworkshop.com/doc/22/corners-positions-schema-of-an-image.html
      *
-     * @param ImageWorkshop $layer
+     * @param ImageWorkshopLayer $layer
      * @param integer $positionX
      * @param integer $positionY
      * @param string $position


### PR DESCRIPTION
.... The $layer parameter should be an instance of ImageWorkshopLayer, not ImageWorkshop

This produces warnings in IDE's that use the docblocks for code hinting, such as IntelliJ.