### PR TITLE
Fix image orientation based on EXIF data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-gd": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.5"
+    },
     "autoload": {
         "psr-0": { "PHPImageWorkshop": "src" }
     }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "ext-exif": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"

--- a/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
+++ b/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
@@ -2,6 +2,7 @@
 
 namespace PHPImageWorkshop\Core;
 
+use PHPImageWorkshop\Exif\ExifOrientations;
 use PHPImageWorkshop\ImageWorkshop as ImageWorkshop;
 use PHPImageWorkshop\Core\ImageWorkshopLib as ImageWorkshopLib;
 use PHPImageWorkshop\Core\Exception\ImageWorkshopLayerException as ImageWorkshopLayerException;
@@ -1872,43 +1873,43 @@ class ImageWorkshopLayer
      */
     public function fixOrientation()
     {
-        if (!isset($this->exif['Orientation'])) {
+        if (!isset($this->exif['Orientation']) || 0 == $this->exif['Orientation']) {
             return;
         }
 
         switch ($this->exif['Orientation']) {
-            case 2:
+            case ExifOrientations::TOP_RIGHT:
                 $this->flip('horizontal');
             break;
 
-            case 3:
+            case ExifOrientations::BOTTOM_RIGHT:
                 $this->rotate(180);
             break;
 
-            case 4:
+            case ExifOrientations::BOTTOM_LEFT:
                 $this->flip('vertical');
             break;
 
-            case 5:
+            case ExifOrientations::LEFT_TOP:
                 $this->rotate(-90);
                 $this->flip('vertical');
             break;
 
-            case 6:
+            case ExifOrientations::RIGHT_TOP:
                 $this->rotate(90);
             break;
 
-            case 7:
+            case ExifOrientations::RIGHT_BOTTOM:
                 $this->rotate(90);
                 $this->flip('horizontal');
             break;
 
-            case 8:
+            case ExifOrientations::LEFT_BOTTOM:
                 $this->rotate(-90);
             break;
         }
 
-        $this->exif['Orientation'] = 1;
+        $this->exif['Orientation'] = ExifOrientations::TOP_LEFT;
     }
     
     // Deprecated, don't use anymore

--- a/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
+++ b/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
@@ -84,6 +84,13 @@ class ImageWorkshopLayer
      * Background Image
      */
     protected $image;
+
+    /**
+     * @var array
+     *
+     * Exif data
+     */
+    protected $exif;
     
     /**
      * @var string
@@ -132,7 +139,7 @@ class ImageWorkshopLayer
      *
      * @param \resource $image
      */
-    public function __construct($image)
+    public function __construct($image, array $exif = array())
     {
         if (!extension_loaded('gd')) {
             throw new ImageWorkshopLayerException('PHPImageWorkshop requires the GD extension to be loaded.', static::ERROR_GD_NOT_INSTALLED);
@@ -145,6 +152,7 @@ class ImageWorkshopLayer
         $this->width = imagesx($image);
         $this->height = imagesy($image);
         $this->image = $image;
+        $this->exif = $exif;
         $this->layers = $this->layerLevels = $this->layerPositions = array();
         $this->clearStack();
     }
@@ -1857,6 +1865,50 @@ class ImageWorkshopLayer
 
         unset($this->image);
         $this->image = $virginLayoutImage;
+    }
+
+    /**
+     * Fix image orientation based on exif data
+     */
+    public function fixOrientation()
+    {
+        if (!isset($this->exif['Orientation'])) {
+            return;
+        }
+
+        switch ($this->exif['Orientation']) {
+            case 2:
+                $this->flip('horizontal');
+            break;
+
+            case 3:
+                $this->rotate(180);
+            break;
+
+            case 4:
+                $this->flip('vertical');
+            break;
+
+            case 5:
+                $this->rotate(-90);
+                $this->flip('vertical');
+            break;
+
+            case 6:
+                $this->rotate(90);
+            break;
+
+            case 7:
+                $this->rotate(90);
+                $this->flip('horizontal');
+            break;
+
+            case 8:
+                $this->rotate(-90);
+            break;
+        }
+
+        $this->exif['Orientation'] = 1;
     }
     
     // Deprecated, don't use anymore

--- a/src/PHPImageWorkshop/Exif/ExifOrientations.php
+++ b/src/PHPImageWorkshop/Exif/ExifOrientations.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PHPImageWorkshop\Exif;
+
+/**
+ * Container for all EXIF orientations.
+ */
+final class ExifOrientations
+{
+    const UNDEFINED    = 0;
+    const TOP_LEFT     = 1;
+    const TOP_RIGHT    = 2;
+    const BOTTOM_RIGHT = 3;
+    const BOTTOM_LEFT  = 4;
+    const LEFT_TOP     = 5;
+    const RIGHT_TOP    = 6;
+    const RIGHT_BOTTOM = 7;
+    const LEFT_BOTTOM  = 8;
+}

--- a/src/PHPImageWorkshop/ImageWorkshop.php
+++ b/src/PHPImageWorkshop/ImageWorkshop.php
@@ -49,10 +49,11 @@ class ImageWorkshop
      * From an upload form, you can give the "tmp_name" path
      * 
      * @param string $path
+     * @param bool $fixOrientation
      * 
      * @return ImageWorkshopLayer
      */
-    public static function initFromPath($path)
+    public static function initFromPath($path, $fixOrientation = false)
     {
         if (file_exists($path) && !is_dir($path)) {
             
@@ -86,8 +87,15 @@ class ImageWorkshop
                     throw new ImageWorkshopException('Not an image file (jpeg/png/gif) at "'.$path.'"', static::ERROR_NOT_AN_IMAGE_FILE);
                 break;
             }
-            
-            return new ImageWorkshopLayer($image);
+
+            $exif = read_exif_data($path);
+            $layer = new ImageWorkshopLayer($image, $exif);
+
+            if ($fixOrientation) {
+                $layer->fixOrientation();
+            }
+
+            return $layer;
         }
         
         throw new ImageWorkshopException('No such file found at "'.$path.'"', static::ERROR_IMAGE_NOT_FOUND);

--- a/src/PHPImageWorkshop/ImageWorkshop.php
+++ b/src/PHPImageWorkshop/ImageWorkshop.php
@@ -69,10 +69,12 @@ class ImageWorkshop
             }
             
             $mimeContentType = $mimeContentType[1];
+            $exif = array();
             
             switch ($mimeContentType) {
                 case 'jpeg':
                     $image = imageCreateFromJPEG($path);
+                    $exif = read_exif_data($path);
                 break;
 
                 case 'gif':
@@ -88,7 +90,6 @@ class ImageWorkshop
                 break;
             }
 
-            $exif = read_exif_data($path);
             $layer = new ImageWorkshopLayer($image, $exif);
 
             if ($fixOrientation) {


### PR DESCRIPTION
Proposal for issue #62

PHP doesn't have a proper method to write EXIF data. EXIF data contain image orientation which is used by many camera to display image in the right orientation.

This PR read EXIF and apply a transformation to image to keep it in right orientation.

PS: you can used this images to tests the code (https://drive.google.com/file/d/0B-bWnVSgvyP-Vmp3T0ZCd1ZBb2s/view?usp=sharing)