### PR TITLE
Update pasteImage to use gd functions for width + height.

### DIFF
--- a/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
+++ b/src/PHPImageWorkshop/Core/ImageWorkshopLayer.php
@@ -532,7 +532,7 @@ class ImageWorkshopLayer
             $positionY = round(($positionY / 100) * $this->height);
         }
 
-        imagecopy($this->image, $image, $positionX, $positionY, 0, 0, $image->getWidth(), $image->getHeight());
+        imagecopy($this->image, $image, $positionX, $positionY, 0, 0, imagesx($image), imagesy($image));
     }
     
     // Change sublayer positions


### PR DESCRIPTION
I noticed pasteImage function was failing due to invalid calls `$image->getWidth()` and `$image->getHeight()`, use the gd functions instead.