### PR TITLE
fixed Fatal error: You must give a php image var to initialize a layer

### DIFF
--- a/src/Core/ImageWorkshopLayer.php
+++ b/src/Core/ImageWorkshopLayer.php
@@ -156,7 +156,7 @@ class ImageWorkshopLayer
             throw new ImageWorkshopLayerException('PHPImageWorkshop requires the GD extension to be loaded.', static::ERROR_GD_NOT_INSTALLED);
         }
 
-        if (gettype($image) != 'resource' && gettype($image) != '\resource') {
+        if (gettype($image) != 'resource' && gettype($image) != '\resource' && gettype($image) != 'object') {
             throw new ImageWorkshopLayerException('You must give a php image var to initialize a layer.', static::ERROR_PHP_IMAGE_VAR_NOT_USED);
         }
 


### PR DESCRIPTION
NOTE: I am using php (v8 x64) cli web server under Windows 10 Professional

I don't know if this applies to all environments

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| Fixed tickets | #53
| License       | MIT

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
