### PR TITLE
Fix in convertHexToRGB method. PHP 8.1 does not allow the input strin…

### DIFF
--- a/src/Core/ImageWorkshopLib.php
+++ b/src/Core/ImageWorkshopLib.php
@@ -70,7 +70,7 @@ class ImageWorkshopLib
     /**
      * Convert Hex color to RGB color format
      *
-     * @param string $hex
+     * @param string|null $hex
      *
      * @return array
      */

--- a/src/Core/ImageWorkshopLib.php
+++ b/src/Core/ImageWorkshopLib.php
@@ -77,9 +77,9 @@ class ImageWorkshopLib
     public static function convertHexToRGB($hex)
     {
         return array(
-            'R' => (int) base_convert(substr($hex, 0, 2), 16, 10),
-            'G' => (int) base_convert(substr($hex, 2, 2), 16, 10),
-            'B' => (int) base_convert(substr($hex, 4, 2), 16, 10),
+            'R' => (int) base_convert(substr($hex ?? '', 0, 2), 16, 10),
+            'G' => (int) base_convert(substr($hex ?? '', 2, 2), 16, 10),
+            'B' => (int) base_convert(substr($hex ?? '', 4, 2), 16, 10),
         );
     }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug report?      | yes
| Feature request? | no
| Usage question?  | no
| PHP version used | 8.1

Fix in convertHexToRGB method. PHP 8.1 does not allow the input string to be null. What causes: `<b>Deprecated</b>:  substr(): Passing null to parameter #1 ($string) of type string is deprecated in <b>\vendor\sybio\image-workshop\src\Core\ImageWorkshopLib.php</b> on line <b>80</b><br />`


### Suggested fix

On lines 80, 81 and 82 of the `src/Core/ImageWorkshopLib.php` file, change the `convertHexToRGB` method by adding `?? ''`, as below:

```php
public static function convertHexToRGB($hex)
     {
         return array(
             'R' => (int) base_convert(substr($hex ?? '', 0, 2), 16, 10),
             'G' => (int) base_convert(substr($hex ?? '', 2, 2), 16, 10),
             'B' => (int) base_convert(substr($hex ?? '', 4, 2), 16, 10),
         );
     }
```